### PR TITLE
build: modify workflows and ignore build result

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,5 +14,5 @@ jobs:
         uses: threeal/ros2-ci@v1.0.0
         with:
           ros2-distro: foxy
-          apt-packages: ros-foxy-gazebo-ros libopencv-dev
-          external-repos: threeal/shisen threeal/shisen_opencv
+          pre-install: sudo apt update && sudo apt install -y curl && curl -s http://repository.ichiro-its.org/debian/setup.bash | bash -s
+          apt-packages: libopencv-dev ros-foxy-gazebo-ros ros-foxy-gazebo-dev ros-foxy-shisen-opencv

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@
 build
 log
 install
+
+debian
+obj-x86_64-linux-gnu
+
+*.deb
+*.ddeb


### PR DESCRIPTION
- Modify workflows to use Apt packages.
- Ignore deb build result.
